### PR TITLE
fix(bug): can't assign localStorage.{get,set}Item to variable

### DIFF
--- a/src/lib/browser.js
+++ b/src/lib/browser.js
@@ -4,6 +4,24 @@ import debugLib from 'debug';
 import { debouncePayloads } from './index';
 import { getPayloadKey, combinePreviousPayloads } from './utils';
 
+const defaultFetchPayload = (key) => {
+  if (typeof window !== 'undefined') {
+    return window.localStorage.getItem(key);
+  }
+  throw new Error(
+    'Unable to fetch payload outside of a browser environment by default. Please specify fetchPayload.',
+  );
+};
+
+const defaultPersistPayload = (key, serializedPayload) => {
+  if (typeof window !== 'undefined') {
+    return window.localStorage.setItem(key, serializedPayload);
+  }
+  throw new Error(
+    'Unable to persist payload outside of a browser environment by default. Please specify persistPayload.',
+  );
+};
+
 /**
  * `debouncePayloadSync` provides a full solution that integrates with the
  * Analytics.js Source Middleware to debounce data before it is sent
@@ -38,8 +56,8 @@ import { getPayloadKey, combinePreviousPayloads } from './utils';
 export const debouncePayloadSync = (
   payload,
   {
-    fetchPayload = _get(global, 'localStorage.getItem'),
-    persistPayload = _get(global, 'localStorage.setItem'),
+    fetchPayload = defaultFetchPayload,
+    persistPayload = defaultPersistPayload,
   } = {},
 ) => {
   const debug = debugLib('debouncePayloadSync');


### PR DESCRIPTION
## Description

- `localStorage.getItem` and `localStorage.setItem` cannot be set to a variable. Instead look for the override inline and use these two functions directly.

<!--
Add relevant details about the changes you've made to ease review process.
Try to provide context if needed in a short, concise, bullet list 🤓
-->

## Pre-Merge Checklist

<!--
Please run through each applicable checklist and change [ ] to [x] to check an item.
Remove any checklist items that are not relevant.
-->

### Technical Requirements

- [x] I have reviewed my own code prior to submitting and have tested for regressions in relevant functionality

## Proof of Functionality

### Key is set correctly in local storage
![image](https://user-images.githubusercontent.com/459925/131004687-a627309f-e594-4e85-8f19-93f9cf1bff18.png)

### Changes are fetched from local storage to produce a diff
![image](https://user-images.githubusercontent.com/459925/131004853-91bd1abd-e0c1-42cf-aa1a-09a640dcf4f0.png)


<!--
Please provide screenshots and/or screen recordings (of terminal output, etc.)
to show the changes in this PR working as intended.

This section is required, unless:
-   Automated tests are included to cover the changes
-->
